### PR TITLE
Target Melodic / C++11 on Master

### DIFF
--- a/src/segway_rmp_node.cpp
+++ b/src/segway_rmp_node.cpp
@@ -47,7 +47,7 @@ void handleDebugMessages(const std::string &msg) {ROS_DEBUG("%s",msg.c_str());}
 void handleInfoMessages(const std::string &msg) {ROS_INFO("%s",msg.c_str());}
 void handleErrorMessages(const std::string &msg) {ROS_ERROR("%s",msg.c_str());}
 
-void handleStatusWrapper(segwayrmp::SegwayStatus::Ptr &ss);
+void handleStatusWrapper(segwayrmp::SegwayStatus::Ptr ss);
 
 // ROS Node class
 class SegwayRMPNode {
@@ -637,7 +637,7 @@ private:
 };
 
 // Callback wrapper
-void handleStatusWrapper(segwayrmp::SegwayStatus::Ptr &ss) {
+void handleStatusWrapper(segwayrmp::SegwayStatus::Ptr ss) {
     segwayrmp_node_instance->handleStatus(ss);
 }
 


### PR DESCRIPTION
This introduces small changes that allows this repository to compile when using ROS Melodic, which uses more strict compilation requirements.

This has been tested as working on a real robot, but may require changes in the `libsegwayrmp` (branch: cpp11) library to be propagated on a local system for it to behave as expected. 